### PR TITLE
tag urls missing backslash

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Setup theme `index.html`, example:
 			<div class="tags">
 				<!-- display page tags with proper urls -->
 				{% for tag in page.tags %}
-						<a href="{{ base_url }}tag/{{ tag }}">#{{ tag }}</a>
+						<a href="{{ base_url }}/tag/{{ tag }}">#{{ tag }}</a>
 				{% endfor %}
 			</div>
 			<p>
@@ -52,7 +52,7 @@ Setup theme `index.html`, example:
 		<div class="tags">
 			<!-- display single page tags with proper urls -->
 			{% for tag in meta.tags %}
-				<a href="{{ base_url }}tag/{{ tag }}">#{{ tag }}</a>
+				<a href="{{ base_url }}/tag/{{ tag }}">#{{ tag }}</a>
 			{% endfor %}
 		</div>
 		<p>


### PR DESCRIPTION
If a blog post has no tags in the head/meta section (even if it doesn't have the word Tags: ,in fact) it shows up in all tag-link result pages. In other words, if I have pages with Tag: pico, and click on that tag-link, any pages with no tags whatsoever will show up in the resulting page, as well as, of course, the pages that have the pico tag.
