### PR TITLE
Trim tags

### DIFF
--- a/pico_tags.php
+++ b/pico_tags.php
@@ -32,7 +32,7 @@ class Pico_Tags {
 		}
 
 		// only set $headers['tags'] if there are any
-		if (strlen($headers['tags']) > 1) $headers['tags'] = explode(',', $headers['tags']);
+		if (strlen($headers['tags']) > 1) $headers['tags'] = array_map('trim', explode(',', $headers['tags']));
 		else $headers['tags'] = NULL;
 
 		return $headers;


### PR DESCRIPTION
Added array_map('trim'... to the explode() function call.

"Tags: foo, bar, baz" will cause links like "tags/%20foo", "tags/%20bar" etc
